### PR TITLE
replace view.propTypes to ViewPropTypes for 0.49+

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { View, ListView, Dimensions } from 'react-native';
+import { View, ListView, Dimensions, ViewPropTypes } from 'react-native';
 import { chunkArray } from './utils';
 
 class SuperGrid extends Component {
@@ -100,7 +100,7 @@ SuperGrid.propTypes = {
   itemWidth: PropTypes.number,
   fixed: PropTypes.bool,
   spacing: PropTypes.number,
-  style: View.propTypes.style,
+  style: ViewPropTypes.style,
   staticWidth: PropTypes.number
 };
 


### PR DESCRIPTION
closes #13 

- [x] add `import { View, ListView, Dimensions, ViewPropTypes } from 'react-native';`
- [x] change the `style: View.PropTypes.style` to `style: ViewPropTypes.style`