### PR TITLE
Fixed render empty section headers Warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,6 +131,7 @@ class SuperGrid extends Component {
 
     return (
       <ListView
+        enableEmptySections
         style={[{ paddingTop: spacing }, style]}
         onLayout={this.onLayout}
         dataSource={ds.cloneWithRows(rows)}


### PR DESCRIPTION
Here's the warning
```
Warning: In next release empty section headers will be rendered. 
In this release you can use 'enableEmptySections' flag to render empty section headers.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saleel/react-native-super-grid/18)
<!-- Reviewable:end -->
