### PR TITLE
lisKey Prop added to FlatList and SectionList

### DIFF
--- a/FlatGrid.js
+++ b/FlatGrid.js
@@ -165,6 +165,7 @@ FlatGrid.propTypes = {
   staticDimension: PropTypes.number,
   horizontal: PropTypes.bool,
   onLayout: PropTypes.func,
+  listKey: PropTypes.string,
 };
 
 FlatGrid.defaultProps = {
@@ -176,6 +177,7 @@ FlatGrid.defaultProps = {
   staticDimension: undefined,
   horizontal: false,
   onLayout: null,
+  listKey: undefined,
 };
 
 export default FlatGrid;

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ import { SectionGrid } from 'react-native-super-grid';
 | staticDimension | Number | undefined | Specifies a static width or height for the container. If not passed, full width/height of the screen will be used.|
 | horizontal | boolean | false | If true, the grid will be scrolling horizontally. If you want your item to fill the height when using a horizontal grid, you should give it a height of '100%'. This prop doesn't affect the SectionGrid, which only scrolls vertically. |
 | onLayout | Function |  | Optional callback ran by the internal `FlatList` or `SectionList`'s `onLayout` function, thus invoked on mount and layout changes. |
+| listKey | String | undefined | A unique identifier for the Grid. This key is necessary if you are nesting multiple FlatGrid/SectionGrid inside another Grid (or any VirtualizedList).|
 
 All additional props you pass will be passed on to the internal FlatList/SectionList. This means you can make use of various props and methods like `ListHeaderComponent`, `onEndReached`, `onRefresh`...etc. While these are not tested for compatibility, most of them should work as expected.
 

--- a/SectionGrid.js
+++ b/SectionGrid.js
@@ -158,6 +158,7 @@ SectionGrid.propTypes = {
   itemContainerStyle: ViewPropTypes.style,
   staticDimension: PropTypes.number,
   onLayout: PropTypes.func,
+  listKey: PropTypes.string,
 };
 
 SectionGrid.defaultProps = {
@@ -168,6 +169,7 @@ SectionGrid.defaultProps = {
   itemContainerStyle: undefined,
   staticDimension: undefined,
   onLayout: null,
+  listKey: undefined,
 };
 
 export default SectionGrid;

--- a/index.d.ts
+++ b/index.d.ts
@@ -111,6 +111,12 @@ export interface FlatGridProps<ItemType = any> {
    * falls back to using the index, like React does.
    */
   keyExtractor?: (item: ItemT[], index: number) => string;
+
+  /**
+   * This prop can be used when the same Grid, component is used several times inside the cell of
+   * an outer list
+   */
+  listKey?: string;
 }
 
 /**
@@ -130,6 +136,7 @@ export interface SectionGridProps<ItemType = any> {
   staticDimension?: number;
   renderSectionHeader?: (info: { section: SectionListData<ItemType> }) => JSX.Element;
   onLayout?: Function;
+  listKey?: string;
 }
 
 export class SectionGrid<ItemType = any> extends React.Component<

--- a/index.d.ts
+++ b/index.d.ts
@@ -110,11 +110,11 @@ export interface FlatGridProps<ItemType = any> {
    * and as the react key to track item re-ordering. The default extractor checks `item.key`, then
    * falls back to using the index, like React does.
    */
-  keyExtractor?: (item: ItemT[], index: number) => string;
+  keyExtractor?: (item: ItemType[], index: number) => string;
 
   /**
-   * This prop can be used when the same Grid, component is used several times inside the cell of
-   * an outer list
+   * A unique identifier for the Grid. This key is necessary if you are nesting multiple
+   * FlatGrid/SectionGrid inside another Grid (or any VirtualizedList)
    */
   listKey?: string;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-super-grid",
-  "version": "3.0.0",
+  "version": "3.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
When several react-native-super-grid components are used inside some cell that is inside of another FlatList or SectionList, React complains because they are placed inside the mentioned cell and needs to identify the siblings. 