### PR TITLE
Support overriding of renderItem in SectionList

### DIFF
--- a/SectionGrid.js
+++ b/SectionGrid.js
@@ -45,6 +45,7 @@ class SectionGrid extends Component {
   }
 
   renderRow({
+    renderItem,
     rowItems,
     rowIndex,
     section,
@@ -54,7 +55,7 @@ class SectionGrid extends Component {
     isFirstRow,
     containerStyle,
   }) {
-    const { spacing, itemContainerStyle, renderItem } = this.props;
+    const { spacing, itemContainerStyle } = this.props;
 
     // Add spacing below section header
     let additionalRowStyle = {};
@@ -115,11 +116,24 @@ class SectionGrid extends Component {
       fixed,
     });
 
+    const wrapRenderItem = (renderItem) => ({ item, index, section }) =>
+      this.renderRow({
+        renderItem,
+        rowItems: item,
+        rowIndex: index,
+        section,
+        isFirstRow: index === 0,
+        itemsPerRow,
+        rowStyle,
+        containerStyle,
+      })
+
     const groupedSections = sections.map((section) => {
       const chunkedData = chunkArray(section.data, itemsPerRow);
 
       return {
         ...section,
+        ...(section.renderItem ? { renderItem: wrapRenderItem(section.renderItem) } : {}),
         data: chunkedData,
         originalData: section.data,
       };
@@ -129,15 +143,7 @@ class SectionGrid extends Component {
     return (
       <SectionList
         sections={groupedSections}
-        renderItem={({ item, index, section }) => this.renderRow({
-          rowItems: item,
-          rowIndex: index,
-          section,
-          isFirstRow: index === 0,
-          itemsPerRow,
-          rowStyle,
-          containerStyle,
-        })}
+        renderItem={wrapRenderItem(this.props.renderItem)}
         keyExtractor={(_, index) => `row_${index}`}
         style={style}
         onLayout={this.onLayout}
@@ -149,7 +155,7 @@ class SectionGrid extends Component {
 }
 
 SectionGrid.propTypes = {
-  renderItem: PropTypes.func.isRequired,
+  renderItem: PropTypes.func,
   sections: PropTypes.arrayOf(PropTypes.any).isRequired,
   itemDimension: PropTypes.number,
   fixed: PropTypes.bool,

--- a/SectionGrid.js
+++ b/SectionGrid.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import {
-  View, Dimensions, ViewPropTypes, SectionList,
+  View, Dimensions, ViewPropTypes, SectionList
 } from 'react-native';
 import PropTypes from 'prop-types';
 import { generateStyles, calculateDimensions, chunkArray } from './utils';
@@ -93,7 +93,7 @@ class SectionGrid extends Component {
       fixed,
       itemDimension,
       staticDimension,
-      renderItem,
+      renderItem: originalRenderItem,
       onLayout,
       ...restProps
     } = this.props;
@@ -116,34 +116,29 @@ class SectionGrid extends Component {
       fixed,
     });
 
-    const wrapRenderItem = (renderItem) => ({ item, index, section }) =>
-      this.renderRow({
-        renderItem,
-        rowItems: item,
-        rowIndex: index,
-        section,
-        isFirstRow: index === 0,
-        itemsPerRow,
-        rowStyle,
-        containerStyle,
-      })
-
     const groupedSections = sections.map((section) => {
       const chunkedData = chunkArray(section.data, itemsPerRow);
-
+      const renderItem = section.renderItem || originalRenderItem;
       return {
         ...section,
-        ...(section.renderItem ? { renderItem: wrapRenderItem(section.renderItem) } : {}),
+        renderItem: ({ item, index, section }) => this.renderRow({
+          renderItem,
+          rowItems: item,
+          rowIndex: index,
+          section,
+          isFirstRow: index === 0,
+          itemsPerRow,
+          rowStyle,
+          containerStyle,
+        }),
         data: chunkedData,
         originalData: section.data,
       };
     });
 
-
     return (
       <SectionList
         sections={groupedSections}
-        renderItem={wrapRenderItem(this.props.renderItem)}
         keyExtractor={(_, index) => `row_${index}`}
         style={style}
         onLayout={this.onLayout}

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,12 +24,6 @@ export type GridRenderItem<ItemT> = (
 
 // Custom props that are present in both grid and list
 type CommonProps<ItemType> = {
-
-  /**
-   * Function to render each object. Should return a react native component.
-   */
-  renderItem: GridRenderItem<ItemType>;
-
   /**
    * Minimum width or height for each item in pixels (virtual).
    */
@@ -57,7 +51,6 @@ type CommonProps<ItemType> = {
 // Original flat list component props
 type FlatListAllowedProps<ItemType = any> = Omit<FlatListProps<ItemType>,
   | "data"
-  | "renderItem"
 >
 
 /**
@@ -65,7 +58,6 @@ type FlatListAllowedProps<ItemType = any> = Omit<FlatListProps<ItemType>,
  */
 export interface FlatGridProps<ItemType = any>
   extends FlatListAllowedProps<ItemType>, CommonProps<ItemType> {
-
   /**
    * Items to be rendered. renderItem will be called with each item in this array.
    */
@@ -87,11 +79,11 @@ export class FlatGrid<ItemType = any> extends React.Component<
 export type SectionItem<ItemType> = {
   title: string;
   data: ItemType[];
+  renderItem?: GridRenderItem<ItemType>;
 }
 
 // Original section list component props
 type SectionGridAllowedProps<ItemType = any> = Omit<SectionListProps<ItemType>,
-  | "renderItem"
   //  This prop doesn't affect the SectionGrid, which only scrolls vertically.
   | "horizontal"
 >


### PR DESCRIPTION
With `SectionList` in React Native it is possible to override the `renderItem` function for each section.

For instance, the following example from the React Native documentation demonstrates this:

```javascript
const overrideRenderItem = ({ item, index, section: { title, data } }) => <Text key={index}>Override{item}</Text>

<SectionList
  renderItem={({ item, index, section }) => <Text key={index}>{item}</Text>}
  sections={[
    { title: 'Title1', data: ['item1', 'item2'], renderItem: overrideRenderItem },
    { title: 'Title2', data: ['item3', 'item4'] },
    { title: 'Title3', data: ['item5', 'item6'] },
  ]}
/>
```

react-native-super-grid does not currently support this. This PR adds support for the same thing to react-native-super-grid.

I have not changed the documentation since it already states that the `section` property has the "Same signature as that of FlatList/SectionList".

The `renderItem` property is no longer required on `SectionGrid` just like it isn't on `SectionList`. I've updated the TypeScript types such that they simply use the `renderItem` property from the React Native types.