### PR TITLE
feat: add support for keyExtractor inside items

### DIFF
--- a/FlatGrid.js
+++ b/FlatGrid.js
@@ -59,7 +59,7 @@ class FlatGrid extends React.Component {
     containerStyle,
   }) {
     const {
-      spacing, horizontal, itemContainerStyle, renderItem,
+      spacing, horizontal, itemContainerStyle, renderItem, keyExtractor,
     } = this.props;
 
     // To make up for the top padding
@@ -75,7 +75,7 @@ class FlatGrid extends React.Component {
       <View style={[rowStyle, additionalRowStyle]}>
         {rowItems.map((item, i) => (
           <View
-            key={`item_${(rowIndex * itemsPerRow) + i}`}
+            key={keyExtractor ? keyExtractor(item, i) : `item_${(rowIndex * itemsPerRow) + i}`}
             style={[containerStyle, itemContainerStyle]}
           >
             {renderItem({
@@ -102,6 +102,7 @@ class FlatGrid extends React.Component {
       onLayout,
       staticDimension,
       itemContainerStyle,
+      keyExtractor,
       ...restProps
     } = this.props;
 
@@ -145,7 +146,15 @@ class FlatGrid extends React.Component {
           style,
         ]}
         onLayout={this.onLayout}
-        keyExtractor={(_, index) => `row_${index}`}
+        keyExtractor={(rowItems, index) => {
+          if (keyExtractor) {
+            return rowItems.map((rowItem, rowItemIndex) => {
+              return keyExtractor(rowItem, rowItemIndex)
+            }).join('_')
+          } else {
+            return `row_${index}`
+          }
+        }}
         {...restProps}
         horizontal={horizontal}
         ref={(flatList) => { this.flatList = flatList; }}

--- a/SectionGrid.js
+++ b/SectionGrid.js
@@ -55,7 +55,7 @@ class SectionGrid extends Component {
     isFirstRow,
     containerStyle,
   }) {
-    const { spacing, itemContainerStyle } = this.props;
+    const { spacing, itemContainerStyle, keyExtractor } = this.props;
 
     // Add spacing below section header
     let additionalRowStyle = {};
@@ -69,7 +69,7 @@ class SectionGrid extends Component {
       <View style={[rowStyle, additionalRowStyle]}>
         {rowItems.map((item, i) => (
           <View
-            key={`item_${(rowIndex * itemsPerRow) + i}`}
+            key={keyExtractor ? keyExtractor(item, i) : `item_${(rowIndex * itemsPerRow) + i}`}
             style={[containerStyle, itemContainerStyle]}
           >
             {renderItem({
@@ -95,6 +95,7 @@ class SectionGrid extends Component {
       staticDimension,
       renderItem: originalRenderItem,
       onLayout,
+      keyExtractor,
       ...restProps
     } = this.props;
 
@@ -139,7 +140,15 @@ class SectionGrid extends Component {
     return (
       <SectionList
         sections={groupedSections}
-        keyExtractor={(_, index) => `row_${index}`}
+        keyExtractor={(rowItems, index) => {
+          if (keyExtractor) {
+            return rowItems.map((rowItem, rowItemIndex) => {
+              return keyExtractor(rowItem, rowItemIndex)
+            }).join('_')
+          } else {
+            return `row_${index}`
+          }
+        }}
         style={style}
         onLayout={this.onLayout}
         ref={(sectionList) => { this.sectionList = sectionList; }}


### PR DESCRIPTION
Resolves #124

Takes the advice in the last comment, and just calls the `keyExtractor` if it is available (if not, it uses the logic already in place).

Also, when generating the keys for the individual rows, it concatenates the result together to generate the final row key (which should be unique, as long as the individual items are unique).

Using my branch inside the project I'm currently working on, and it all appears to be working fine.