### PR TITLE
Added extra items to notify that the rerender is necessary.

### DIFF
--- a/SectionGrid.js
+++ b/SectionGrid.js
@@ -161,6 +161,7 @@ const SectionGrid = memo(
     return (
       <View onLayout={onLocalLayout}>
         <SectionList
+          extraData={totalDimension}
           sections={groupedSections}
           keyExtractor={localKeyExtractor}
           style={style}


### PR DESCRIPTION
With the new layout implementation wrapped with View, seems like whyDidYouRender thinks that it shouldn't render due to all of the values from `section` are identical so need to notify `SectionList` that the rerender is valid so added the extra prop to properly notify that it's a correct render when the `totalDimension` ends up changing. 

Think it will help with this issue here as well https://github.com/saleel/react-native-super-grid/issues/133 since that responsive change should be dealing with onLayout view change but I didn't look too much into it. 