### PR TITLE
(FlatGrid) Fill space if data length is less than what can fit on a row

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ node_modules
 
 # Optional REPL history
 .node_repl_history
+
+# IntelliJ Files
+.idea/

--- a/FlatGrid.js
+++ b/FlatGrid.js
@@ -23,6 +23,7 @@ const FlatGrid = memo(
       maxDimension,
       itemContainerStyle,
       keyExtractor,
+      fillSpace,
       ...restProps
     } = props;
 
@@ -116,8 +117,10 @@ const FlatGrid = memo(
         totalDimension,
         spacing,
         fixed,
+        fillSpace,
+        dataLength: data.length
       }),
-      [itemDimension, staticDimension, totalDimension, spacing, fixed],
+      [itemDimension, staticDimension, totalDimension, spacing, fixed, fillSpace, data],
     );
 
     const { containerStyle, rowStyle } = useMemo(
@@ -192,6 +195,7 @@ FlatGrid.propTypes = {
   itemContainerStyle: ViewPropTypes.style,
   staticDimension: PropTypes.number,
   horizontal: PropTypes.bool,
+  fillSpace: PropTypes.bool,
   onLayout: PropTypes.func,
   keyExtractor: PropTypes.func,
   listKey: PropTypes.string,
@@ -205,6 +209,7 @@ FlatGrid.defaultProps = {
   itemContainerStyle: undefined,
   staticDimension: undefined,
   horizontal: false,
+  fillSpace: false,
   onLayout: null,
   keyExtractor: null,
   listKey: undefined,

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ import { SectionGrid } from 'react-native-super-grid';
 | staticDimension | Number | | Specifies a static width or height for the container. If not passed, `maxDimension` will be used.|
 | maxDimension | Number | | Specifies a maximum width or height for the container. If not passed, full width/height of the screen will be used.|
 | horizontal | boolean | false | If true, the grid will be scrolling horizontally. If you want your item to fill the height when using a horizontal grid, you should give it a height of '100%'. This prop doesn't affect the SectionGrid, which only scrolls vertically. |
+| fillSpace (FlatGrid only) | boolean | false | If true and the number of data items is less than can fit on one row, the items will be sized to fill the row. |
 | onLayout | Function |  | Optional callback ran by the internal `FlatList` or `SectionList`'s `onLayout` function, thus invoked on mount and layout changes. |
 | listKey | String | | A unique identifier for the Grid. This key is necessary if you are nesting multiple FlatGrid/SectionGrid inside another Grid (or any VirtualizedList).|
 | keyExtractor | Function | | A function `(item, rowItemIndex) => {String}` that should return a unique key for the item passed.|

--- a/SectionGrid.js
+++ b/SectionGrid.js
@@ -110,6 +110,8 @@ const SectionGrid = memo(
         totalDimension,
         spacing,
         fixed,
+        fillSpace: false,
+        dataLength: 0 //since fillSpace is false, this value is never used
       }),
       [itemDimension, staticDimension, totalDimension, spacing, fixed],
     );

--- a/index.d.ts
+++ b/index.d.ts
@@ -68,6 +68,12 @@ export interface FlatGridProps<ItemType = any>
    * Specifies the style about content row view
    */
   itemContainerStyle?: StyleProp<ViewStyle>;
+
+  /**
+   * Specifies if the number of items is less than can fit in one row/column if the items should fill
+   * the row's width instead.
+   */
+  fillSpace?: boolean;
 }
 
 /**

--- a/utils.js
+++ b/utils.js
@@ -19,11 +19,16 @@ function calculateDimensions({
   totalDimension,
   fixed,
   spacing,
+  fillSpace,
+  dataLength,
 }) {
   const usableTotalDimension = staticDimension || totalDimension;
   const availableDimension = usableTotalDimension - spacing; // One spacing extra
   const itemTotalDimension = Math.min(itemDimension + spacing, availableDimension); // itemTotalDimension should not exceed availableDimension
-  const itemsPerRow = Math.floor(availableDimension / itemTotalDimension);
+  let itemsPerRow = Math.floor(availableDimension / itemTotalDimension);
+  if (fillSpace && dataLength < itemsPerRow) {
+    itemsPerRow = dataLength;
+  }
   const containerDimension = availableDimension / itemsPerRow;
 
   let fixedSpacing;


### PR DESCRIPTION
If the `fillSpace` option is set to true (false by default), and the number of items to be displayed is less than what could fit on a single row, then the content will be stretched to fill the space.

In my case, I wanted to have the dynamic stretching as well as row splitting, but on tablets having a partially-complete single row looked wrong, so this was a nice solution.