### PR TITLE
Remove ViewPropType.

### DIFF
--- a/FlatGrid.js
+++ b/FlatGrid.js
@@ -2,7 +2,7 @@ import React, {
   forwardRef, memo, useState, useCallback, useMemo,
 } from 'react';
 import {
-  View, Dimensions, ViewPropTypes, FlatList,
+  View, Dimensions, FlatList,
 } from 'react-native';
 import PropTypes from 'prop-types';
 import { chunkArray, calculateDimensions, generateStyles } from './utils';
@@ -188,8 +188,8 @@ FlatGrid.propTypes = {
   itemDimension: PropTypes.number,
   fixed: PropTypes.bool,
   spacing: PropTypes.number,
-  style: ViewPropTypes.style,
-  itemContainerStyle: ViewPropTypes.style,
+  style: PropTypes.object,
+  itemContainerStyle: PropTypes.object,
   staticDimension: PropTypes.number,
   horizontal: PropTypes.bool,
   onLayout: PropTypes.func,

--- a/SectionGrid.js
+++ b/SectionGrid.js
@@ -2,7 +2,7 @@ import React, {
   forwardRef, memo, useCallback, useMemo, useState,
 } from 'react';
 import {
-  View, Dimensions, ViewPropTypes, SectionList,
+  View, Dimensions, SectionList,
 } from 'react-native';
 import PropTypes from 'prop-types';
 import { generateStyles, calculateDimensions, chunkArray } from './utils';
@@ -192,8 +192,8 @@ SectionGrid.propTypes = {
   itemDimension: PropTypes.number,
   fixed: PropTypes.bool,
   spacing: PropTypes.number,
-  style: ViewPropTypes.style,
-  itemContainerStyle: ViewPropTypes.style,
+  style: PropTypes.object,
+  itemContainerStyle: PropTypes.object,
   staticDimension: PropTypes.number,
   onLayout: PropTypes.func,
   listKey: PropTypes.string,


### PR DESCRIPTION
This is depreacted and now longer exists in react-native-web. See:

https://github.com/necolas/react-native-web/issues/1537

Without this change, in a rn-web project I get the error:

Module not found: Can't resolve 'react-native-web/dist/exports/ViewPropTypes' in '/Users/michael/Development/foobar/node_modules/react-native-super-grid'