### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -56,7 +56,12 @@ type CommonProps<ItemType> = {
    * Specifies a maximum width or height for the container. If not passed, full width/height
    * of the screen will be used.
    */
-  maxDimension?: number;
+  maxDimension?: number; 
+  
+  /**
+   * Specifies the style about content row view
+   */
+  itemContainerStyle?: StyleProp<ViewStyle>;
 }
 
 /**
@@ -68,11 +73,6 @@ export interface FlatGridProps<ItemType = any>
    * Items to be rendered. renderItem will be called with each item in this array.
    */
   data: ItemType[];
-
-  /**
-   * Specifies the style about content row view
-   */
-  itemContainerStyle?: StyleProp<ViewStyle>;
 }
 
 /**


### PR DESCRIPTION
<img width="385" alt="image" src="https://user-images.githubusercontent.com/30093692/106586158-04562980-6540-11eb-83ae-56353c74ad1f.png">


Update types that SectionGrid does have `itemContainerStyle`