### PR TITLE
Make title prop for SectionItem optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -99,7 +99,7 @@ export class FlatGrid<ItemType = any> extends React.Component<
 > {}
 
 export type SectionItem<ItemType> = {
-  title: string;
+  title?: string;
   data: ItemType[];
   renderItem?: GridRenderItem<ItemType>;
 }


### PR DESCRIPTION
This is the pull request for [issue #187](https://github.com/saleel/react-native-super-grid/issues/187). In essence, 'title' is not required in the [SectionList props](https://reactnative.dev/docs/sectionlist#section), and thus, is not used in the SectionGrid. It's not an urgent issue, but it does trigger Typescripts error detection. The section above can be found in index.d.ts on lines 101 to 105.
