### PR TITLE
style: update types to handle ref attributes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,9 @@ import {
   SectionListData,
   StyleProp,
   RefreshControlProps,
+  SectionList,
   SectionListProps,
+  FlatList,
   FlatListProps
 } from "react-native"
 
@@ -94,9 +96,9 @@ export interface FlatGridProps<ItemType = any>
 /**
  * Responsive Grid View for React Native.
  */
-export class FlatGrid<ItemType = any> extends React.Component<
-  FlatGridProps<ItemType>
-> {}
+export function FlatGrid<ItemType = any>(
+  props: React.PropsWithoutRef<FlatGridProps<ItemType>> & React.RefAttributes<FlatList<ItemType>>
+): React.ReactElement
 
 export type SectionItem<ItemType> = {
   title?: string;
@@ -116,6 +118,6 @@ export interface SectionGridProps<ItemType = any>
   sections: SectionItem<ItemType>[];
 }
 
-export class SectionGrid<ItemType = any> extends React.Component<
-  SectionGridProps<ItemType>
-> {}
+export function SectionGrid<ItemType = any>(
+  props: React.PropsWithoutRef<SectionGridProps<ItemType>> & React.RefAttributes<SectionList<ItemType>>
+): React.ReactElement


### PR DESCRIPTION
## Context

Updating the types for `FlatGrid` and `SectionGrid` so we can leverage the `ref` attribute for the underlying `SectionList` and `FlatList`.  This allows the consumer to do something like the following:

```ts
import * as React from 'react'

import { FlatList, Text } from 'react-native'
import { FlatGrid } from 'react-native-super-grid'

const DATA = [1, 2, 3, 4]

const MyComponent: React.FC = () => {
  const ref = React.useRef<FlatList<number>>(null)
  
  const onLayout = useCallback(() => {
    if (ref.current == null) return
    
    ref.current.scrollToEnd({ animated: true })
  }, [])
  
  return (
    <FlatGrid
      ref={ref}
      onLayout={onLayout}
      itemDimension={100}
      data={DATA}
      renderItem={({ item }) => <Text>{item}</Text>}
    />
  )
}
```

Without these changes, the components are typed with the `ref` attribute as `FlatGrid<number>`, which doesn't expose any of the methods defined by [`FlatList`](https://reactnative.dev/docs/flatlist#methods).

Image of the typing errors we were running into our project with the current implementation:

<img width="652" alt="Screen Shot 2022-07-26 at 9 15 52 PM" src="https://user-images.githubusercontent.com/4258033/181139517-a0ad3348-090d-40dd-9218-d46ca2c3abc3.png">

Image of the updated types being inferred after these changes are made:

<img width="644" alt="Screen Shot 2022-07-26 at 9 17 14 PM" src="https://user-images.githubusercontent.com/4258033/181139558-59bfdfb9-e7d6-4476-971b-c9f29ed28a7d.png">

## Changes

- [x] Update `FlatGrid` and `SectionGrid` types to be Functional Components with ref attributes inherited from `FlatList` and `SectionList`
   - This is stealing the types used by [`React.forwardRef`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/520611ac055903208510fe828dd24fdb4237e278/types/react/index.d.ts#L780) essentially, which is what is used by the code implementation, anyways