### PR TITLE
Allow readonly support for data types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -106,7 +106,7 @@ export interface FlatGridProps<ItemType = any>
   /**
    * Items to be rendered. renderItem will be called with each item in this array.
    */
-   data: ItemType[];
+   data: readonly ItemType[];
 
   /**
    * Overwrites FlatList with custom interface

--- a/index.d.ts
+++ b/index.d.ts
@@ -149,8 +149,8 @@ export function SimpleGrid<ItemType = any>(
 
 
 export type SectionItem<ItemType> = {
-  title?: string;
-  data: ItemType[];
+  title?: readonly string;
+  data: readonly ItemType[];
   renderItem?: SectionGridRenderItem<ItemType>;
 }
 
@@ -162,7 +162,7 @@ type SectionGridAllowedProps<ItemType = any> = Omit<SectionListProps<ItemType>,
 
 export interface SectionGridProps<ItemType = any>
   extends SectionGridAllowedProps<ItemType>, CommonProps<ItemType> {
-   sections: SectionItem<ItemType>[];
+   sections: readonly SectionItem<ItemType>[];
 
    renderItem?: SectionGridRenderItem<ItemType>;
 


### PR DESCRIPTION
Currently the library lacks readonly support for the data types and allowing for readonly can prevent accidental modifications to the prop values. The library does not need to modify the data, so there is no need for it to **require** modifiable data.