### PR TITLE
changed deps to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "author": "https://github.com/saleel",
   "license": "MIT",
-  "dependencies": {
+  "devDependencies": {
     "eslint": "^8.2.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-plugin-import": "^2.29.1",


### PR DESCRIPTION
All the dependencies in this repository are ESLint dependencies that should be marked as devDependencies. I have marked them as devDependencies.